### PR TITLE
Fix off by one when copying rows

### DIFF
--- a/lib/mysql_big_table_migration.rb
+++ b/lib/mysql_big_table_migration.rb
@@ -95,12 +95,12 @@ module MySQLBigTableMigration
       if max_id_before_migration == 0
         say "Source table is empty, no rows to copy into temporary table"
       else
-        batch_size = 10000
+        batch_size = mysql_big_table_migration_bach_size
         start = fetch_result_row(connection.execute("SELECT MIN(id) FROM #{table_name}"))[0].to_i
         counter = start
         say "Inserting into temporary table in batches of #{batch_size}..."
         say "Approximately #{max_id_before_migration-start+1} rows to process, first row has id #{start}", true
-        while counter < ( max = fetch_result_row(connection.execute("SELECT MAX(id) FROM #{table_name}"))[0].to_i )
+        while counter <= ( max = fetch_result_row(connection.execute("SELECT MAX(id) FROM #{table_name}"))[0].to_i )
           percentage_complete = ( ( ( counter - start ).to_f / ( max - start ).to_f ) * 100 ).to_i
           say "Processing rows with ids between #{counter} and #{(counter+batch_size)-1} (#{percentage_complete}% complete)", true
           connection.execute("INSERT INTO #{new_table_name} (#{new_column_list}) SELECT #{old_column_list} FROM #{table_name} WHERE id >= #{counter} AND id < #{counter + batch_size}")
@@ -134,6 +134,10 @@ module MySQLBigTableMigration
   end
 
   private
+
+  def mysql_big_table_migration_bach_size
+    10000
+  end
 
   def connection
     ActiveRecord::Base.connection

--- a/test/mysql_big_table_migration_test.rb
+++ b/test/mysql_big_table_migration_test.rb
@@ -2,7 +2,7 @@ require_relative 'test_helper'
 
 class MysqlBigTableMigrationTest < Test::Unit::TestCase
   extend DatabaseTest
-  
+
   test_against_all_configs :methods_are_added_to_migration do
     if Rails::VERSION::STRING < "3.0"
       method_target = ActiveRecord::Migration
@@ -20,6 +20,20 @@ class MysqlBigTableMigrationTest < Test::Unit::TestCase
       ActiveRecord::Migration.send(:with_tmp_table, :test_table) {}
     end
     assert_match "CREATE TABLE tmp_new_test_table LIKE test_table", read_log_file
+  end
+
+  class SmallBatchMigration < ActiveRecord::Migration
+    def mysql_big_table_migration_bach_size
+      4
+    end
+  end
+
+  test_against_all_configs :with_tmp_table_copies_all_rows do
+    silence_stream($stdout) do
+      SmallBatchMigration.new.send(:with_tmp_table, :test_table) {}
+    end
+
+    assert_equal 5, test_table_rows.length
   end
 
   test_against_all_configs :add_column_using_tmp_table do


### PR DESCRIPTION
if (# of rows in table % batch size) == 1
then the last row would be missed in the copy.
